### PR TITLE
Reenable StandalonePerspectivesIntegrationTest

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/pom.xml
+++ b/kie-wb-tests/kie-wb-tests-gui/pom.xml
@@ -51,6 +51,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency><!-- Using workbench rest client for UI test setup -->
+      <groupId>org.kie</groupId>
+      <artifactId>kie-wb-tests-rest</artifactId>
+    </dependency>
+
     <!-- utilities -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Un`@Ignore` the test and reimplement setup to clone single-project-repo via Rest before UI test is run (previously we weren't opening any asset in the test).